### PR TITLE
feat: add entity-mappings service + ai-platform action constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiennc24/constant",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/src/collections.constant.ts
+++ b/src/collections.constant.ts
@@ -1312,6 +1312,11 @@ const COLLECTIONS = {
   // Prompt template (system stock + tenant-custom)
   AI_PLATFORM_PROMPT_TEMPLATE_REPOSITORY_NAME: "aiPlatformPromptTemplate",
   AI_PLATFORM_PROMPT_TEMPLATE_COLLECTION_NAME: "ai_platform_prompt_templates",
+
+  // ADMIN — Generic cross-tenant entity mapping (used for webhook routing,
+  // resource ↔ domain lookup, etc.). Discriminator `type` keeps the table reusable.
+  ENTITY_MAPPING_REPOSITORY_NAME: "entityMapping",
+  ENTITY_MAPPING_COLLECTION_NAME: "entity_mappings",
 };
 
 export default COLLECTIONS;

--- a/src/service.constant.json
+++ b/src/service.constant.json
@@ -2640,6 +2640,14 @@
     "ACTION_CREATE": "create",
     "ACTION_DELETE": "delete"
   },
+  "SVC_ADMIN_ENTITY_MAPPINGS": {
+    "NAME": "api-admin.entity-mappings",
+    "ACTION_RESOLVE_MAPPING": "resolveMapping",
+    "ACTION_FIND_BY_TARGET": "findByTargetId",
+    "ACTION_CREATE_MAPPING": "createMapping",
+    "ACTION_SOFT_DELETE_BY_TARGET": "softDeleteByTargetId",
+    "ACTION_UPDATE_DOMAIN": "updateDomainByTargetIds"
+  },
   "SVC_ADMIN_VERIFY_EMAIL_TOKEN": {
     "NAME": "api-admin.verify-email-token"
   },
@@ -3394,6 +3402,8 @@
     "ACTION_TEST_CONNECTION": "testConnection",
     "ACTION_VERIFY_WEBHOOK": "verifyWebhook",
     "ACTION_RECEIVE_WEBHOOK": "receiveWebhook",
+    "ACTION_RECEIVE_WEBHOOK_BY_PLATFORM": "receiveWebhookByPlatform",
+    "ACTION_VERIFY_CONFIG": "verifyConfig",
     "ACTION_RECEIVE_OUTBOUND": "receiveOutbound",
     "ACTION_GET_WIDGET_CHAT": "getWidgetChat",
     "ACTION_UPDATE_WIDGET_CHAT": "updateWidgetChat",
@@ -3467,6 +3477,7 @@
     "NAME": "svc-ai-platform.storage",
     "ACTION_GET_PRESIGNED_UPLOAD": "getPresignedUpload",
     "ACTION_GET_PRESIGNED_DOWNLOAD": "getPresignedDownload",
+    "ACTION_UPLOAD_FILE": "uploadFile",
     "ACTION_VERIFY_FILE": "verifyFile",
     "ACTION_DELETE_FILE": "deleteFile",
     "ACTION_DELETE_FOLDER": "deleteFolder",


### PR DESCRIPTION
- SVC_ADMIN_ENTITY_MAPPINGS service block (resolve, findByTarget, create, softDelete, updateDomain)
- ENTITY_MAPPING repository + collection names
- API_AI_PLATFORM_INTEGRATIONS: receiveWebhookByPlatform, verifyConfig
- API_AI_PLATFORM_STORAGE: uploadFile
- bump version 1.7.8 -> 1.7.9